### PR TITLE
remove github pro options from workflow

### DIFF
--- a/.github/workflows/automerge-prs-from-bot.yml
+++ b/.github/workflows/automerge-prs-from-bot.yml
@@ -21,21 +21,13 @@ on:
 
 jobs:
 
-  autoapprove:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Autoapproving
-        uses: hmarr/auto-approve-action@v2.0.0
-        if: github.actor == 'ddg-ops-bot'
-        with:
-          github-token: "${{ secrets.GH_TOKEN }}"
-
   automerge:
-    needs: [autoapprove]
     runs-on: ubuntu-latest
     steps:
       - name: Automerging
         uses: pascalgn/automerge-action@v0.8.3
+        with:
+          args: "--trace"
         if: github.actor == 'ddg-ops-bot'
         env:
           GITHUB_TOKEN: "${{ secrets.GH_TOKEN }}"


### PR DESCRIPTION
Automerge has been failing and I think it's because of the autoapprove step, which requires branch protection setting, which require github pro, which I don't have for this project.

Hopefully removing those options will make it automerge as intended.
