### PR TITLE
chore(release): 1.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ddg-test-project",
-  "version": "1.5.1",
+  "version": "1.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ddg-test-project",
-  "version": "1.5.1",
+  "version": "1.6.0",
   "private": true,
   "description": "Second test project for DDG - Tracker blocker extension",
   "type": "module",

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "DDG Best Tracker Blocker Ext",
   "description": "Tracker Blocker extension, part of DDG's interview process",
-  "version": "1.5.1",
+  "version": "1.6.0",
   "icons": {
     "16": "images/duck_with_shades_16.png",
     "32": "images/duck_with_shades_32.png",


### PR DESCRIPTION
Bump version in manifest.json, package.json and package-lock.json for [1.6.0](https://github.com/lfilho/ddg-test-project/releases/tag/v1.6.0) release